### PR TITLE
PLATFORM-10096 Modify new upstream to work with Fandom setup

### DIFF
--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -170,7 +170,7 @@ class AppliedFilter {
 		 * Fandom change
 		 * Use SMW Store to get a connection to SMW DB (external cluster compatibility)
 		 */
-		$dbr = $this->store->getConnection( 'mw.db' );
+		$dbr = $this->store->getConnection( DB_REPLICA );
 		if ( $this->search_terms != null ) {
 			$quoteReplace = ( $wgDBtype == 'postgres' ? "''" : "\'" );
 			foreach ( $this->search_terms as $i => $search_term ) {
@@ -266,7 +266,7 @@ class AppliedFilter {
 		 * Fandom change
 		 * Use SMW Store to get a connection to SMW DB (external cluster compatibility)
 		 */
-		$dbr = $this->store->getConnection( 'mw.db' );
+		$dbr = $this->store->getConnection( DB_REPLICA );
 		$wikiDbr = $lb->getConnection( $lb::DB_REPLICA );
 
 		$property_value = $dbr->addQuotes( $this->filter->escapedProperty() );

--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -297,8 +297,11 @@ class AppliedFilter {
 
 		// Construct SQL query
 		// Fandom change - select p.o_id to fetch page titles later
-		$sql = "SELECT $value_field AS value, p.o_id AS o_id
-				FROM $property_table_name p
+		$sql = "SELECT $value_field AS value";
+		if ( $this->filter->propertyType() === 'page' ) {
+			$sql .= ",p.o_id AS o_id";
+		}
+		$sql .= "FROM $property_table_name p
 				JOIN $smw_ids p_ids ON p.p_id = p_ids.smw_id\n";
 		if ( $this->filter->propertyType() === 'page' ) {
 

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -259,7 +259,12 @@ END;
 		$prop_ns = SMW_NS_PROPERTY;
 		// Fandom change - don't use cross-cluster JOIN, return o_id to use in another query
 		$sql = <<<END
-	SELECT $value_field as value, count(DISTINCT sdv.id) as count, p.o_id as o_id
+	SELECT $value_field as value, count(DISTINCT sdv.id) as count
+END;
+		if ( $this->propertyType === 'page' ) {
+			$sql .= ", p.o_id as o_id";
+		}
+		$sql .= <<<END
 	FROM semantic_drilldown_values sdv
 	JOIN $property_table_name p ON sdv.id = p.s_id
 END;

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -246,7 +246,7 @@ END;
 		$possible_values = [];
 		$property_value = $this->escapedProperty();
 		// Fandom change - use external SMW DB connection. $dbw is used as a name to reduce the diff size
-		$dbw = $this->store->getConnection( DB_REPLICA );
+		$dbw = $this->store->getConnection( 'mw.db.queryengine' );
 		$wikiDbr = MediaWikiServices::getInstance()
 			->getDBLoadBalancer()
 			->getMaintenanceConnectionRef( DB_REPLICA );

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -263,16 +263,20 @@ END;
 	FROM semantic_drilldown_values sdv
 	JOIN $property_table_name p ON sdv.id = p.s_id
 END;
-		// Fandom change - start - don't use cross-cluster JOIN
-		/*
+
 		if ( $this->propertyType === 'page' ) {
+			// Fandom change - start - don't use cross-cluster JOIN
+			/*
+				$sql .= <<<END
+		JOIN $smw_ids o_ids ON p.o_id = o_ids.smw_id
+		LEFT JOIN $revision_table_name ON $revision_table_name.rev_id = o_ids.smw_rev
+		LEFT JOIN $page_props_table_name displaytitle ON $revision_table_name.rev_page = displaytitle.pp_page AND displaytitle.pp_propname = 'displaytitle'
+	END;
+			*/
 			$sql .= <<<END
-	JOIN $smw_ids o_ids ON p.o_id = o_ids.smw_id
-	LEFT JOIN $revision_table_name ON $revision_table_name.rev_id = o_ids.smw_rev
-	LEFT JOIN $page_props_table_name displaytitle ON $revision_table_name.rev_page = displaytitle.pp_page AND displaytitle.pp_propname = 'displaytitle'
-END;
-		}
-		*/
+		JOIN $smw_ids o_ids ON p.o_id = o_ids.smw_id
+	END;
+			}
 		$sql .= <<<END
 	JOIN $smw_ids p_ids ON p.p_id = p_ids.smw_id
 	WHERE p_ids.smw_title = '$property_value'
@@ -291,7 +295,7 @@ END;
 			$rows[] = $row;
 		}
 		$o_ids_to_displaytitle = [];
-		if ( $this->propertyType === 'page' ) {
+		if ( $this->propertyType === 'page' && !empty( $rows ) ) {
 			$o_ids = array_column( $rows, 'o_id' );
 			$titlesRows = $wikiDbr->newSelectQueryBuilder()
 				->field( 'revision.rev_id', 'rev_id' )

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -8,6 +8,7 @@ use SD\Sql\SqlProvider;
 use SMWDIProperty;
 use SMWDIUri;
 use SMWDIWikiPage;
+use SMWStore;
 
 /**
  * Defines a class, Filter, that holds the information in a filter.
@@ -24,6 +25,11 @@ class Filter {
 	private ?string $int;
 	private ?string $timePeriod;
 	private $allowedValues;
+	/*
+	 * Fandom change - start
+	 * SMWStore is required to access the SMW DB in an external cluster
+	 */
+	private SMWStore $store;
 
 	/**
 	 * possible applied filters value
@@ -50,6 +56,9 @@ class Filter {
 			$this->allowedValues =
 				$db->getCategoryChildren( $category, false, 5 );
 		}
+
+		// Fandom change
+		$this->store = smwfGetStore();
 	}
 
 	public function name() {
@@ -107,10 +116,9 @@ class Filter {
 		$possible_dates = [];
 		$property_value = $this->escapedProperty();
 		$date_field = PropertyTypeDbInfo::dateField( $this->propertyType() );
-		$dbw = MediaWikiServices::getInstance()
-				->getDBLoadBalancer()
-				->getMaintenanceConnectionRef( DB_PRIMARY );
-		list( $yearValue, $monthValue, $dayValue ) = SqlProvider::getDateFunctions( $date_field );
+		// Fandom change - use external SMW DB connection. $dbw is used as a name to reduce the diff size
+		$dbw = $this->store->getConnection( DB_REPLICA );
+		[ $yearValue, $monthValue, $dayValue ] = SqlProvider::getDateFunctions( $date_field );
 		$fields = "$yearValue, $monthValue, $dayValue";
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
 		$idsTable = $dbw->tableName( Utils::getIDsTableName() );
@@ -237,21 +245,26 @@ END;
 	public function getAllValues(): PossibleFilterValues {
 		$possible_values = [];
 		$property_value = $this->escapedProperty();
-		$dbw = MediaWikiServices::getInstance()
-				->getDBLoadBalancer()
-				->getMaintenanceConnectionRef( DB_PRIMARY );
+		// Fandom change - use external SMW DB connection. $dbw is used as a name to reduce the diff size
+		$dbw = $this->store->getConnection( DB_REPLICA );
+		$wikiDbr = MediaWikiServices::getInstance()
+			->getDBLoadBalancer()
+			->getMaintenanceConnectionRef( DB_REPLICA );
 		$property_table_name = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
-		$revision_table_name = $dbw->tableName( 'revision' );
-		$page_props_table_name = $dbw->tableName( 'page_props' );
+		$revision_table_name = $wikiDbr->tableName( 'revision' );
+		$page_props_table_name = $wikiDbr->tableName( 'page_props' );
 		$value_field = PropertyTypeDbInfo::valueField( $this->propertyType() );
 		$displaytitle = $this->propertyType === 'page' ? 'displaytitle.pp_value' : 'null';
 		$smw_ids = $dbw->tableName( Utils::getIDsTableName() );
 		$prop_ns = SMW_NS_PROPERTY;
+		// Fandom change - don't use cross-cluster JOIN, return o_id to use in another query
 		$sql = <<<END
-	SELECT $value_field as value, $displaytitle as displayTitle, count(DISTINCT sdv.id) as count 
+	SELECT $value_field as value, count(DISTINCT sdv.id) as count, p.o_id as o_id
 	FROM semantic_drilldown_values sdv
 	JOIN $property_table_name p ON sdv.id = p.s_id
 END;
+		// Fandom change - start - don't use cross-cluster JOIN
+		/*
 		if ( $this->propertyType === 'page' ) {
 			$sql .= <<<END
 	JOIN $smw_ids o_ids ON p.o_id = o_ids.smw_id
@@ -259,6 +272,7 @@ END;
 	LEFT JOIN $page_props_table_name displaytitle ON $revision_table_name.rev_page = displaytitle.pp_page AND displaytitle.pp_propname = 'displaytitle'
 END;
 		}
+		*/
 		$sql .= <<<END
 	JOIN $smw_ids p_ids ON p.p_id = p_ids.smw_id
 	WHERE p_ids.smw_title = '$property_value'
@@ -268,23 +282,60 @@ END;
 
 END;
 		$res = $dbw->query( $sql );
+		/*
+		 * Fandom change - start
+		 * Fetch page titles in a separate query to avoid JOINing SMW data with wiki tables
+		 */
+		$rows = [];
 		while ( $row = $res->fetchRow() ) {
+			$rows[] = $row;
+		}
+		$o_ids_to_displaytitle = [];
+		if ( $this->propertyType === 'page' ) {
+			$o_ids = array_column( $rows, 'o_id' );
+			$titlesRows = $wikiDbr->newSelectQueryBuilder()
+				->field( 'revision.rev_id', 'rev_id' )
+				->field('displaytitle.pp_value', 'displayTitle' )
+				->from( $revision_table_name )
+				->leftJoin(
+					$page_props_table_name,
+					'displaytitle',
+					[
+						'revision.rev_page = displaytitle.pp_page',
+						'displaytitle.pp_propname = "displaytitle"'
+					]
+				)
+				->where( [ 'revision.rev_id' => $o_ids ] )
+				->caller( __METHOD__ )
+				->fetchResultSet();
+			foreach ( $titlesRows as $titlesRow ) {
+				$o_ids_to_displaytitle[$titlesRow->rev_id] = $titlesRow->displayTitle;
+			}
+		}
+		foreach ( $rows as $row ) {
+			/*
+			 * Fandom change - end
+			 */
 			$value_string = str_replace( '_', ' ', $row['value'] );
 			// We check this here, and not in the SQL, because
 			// for MySQL, 0 sometimes equals blank.
 			if ( $value_string === '' ) {
 				continue;
 			}
-			$possible_values[] = new PossibleFilterValue( $value_string, $row['count'], htmlspecialchars_decode( $row['displayTitle'] ?? '' ) );
+			// Fandom change - fetch displayTitle from the array instead
+			$possible_values[] = new PossibleFilterValue(
+				$value_string,
+				$row['count'],
+				htmlspecialchars_decode( $o_ids_to_displaytitle[$row['o_id']] ?? '' )
+			);
 		}
 
 		return new PossibleFilterValues( $possible_values );
 	}
 
 	private function getTimePeriod() {
-		$dbw = MediaWikiServices::getInstance()
-				->getDBLoadBalancer()
-				->getMaintenanceConnectionRef( DB_PRIMARY );
+		// Fandom change - use external SMW DB connection. $dbw is used as a name to reduce the diff size
+		$dbw = $this->store->getConnection( DB_REPLICA );
 		$property_value = $this->escapedProperty();
 		$date_field = PropertyTypeDbInfo::dateField( $this->propertyType() );
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
@@ -308,7 +359,7 @@ END;
 		if ( count( $minDateParts ) == 3 ) {
 			// check if array can be used instead of list
 			// [ $minYear, $minMonth, $minDay ] = $minDateParts;
-			list( $minYear, $minMonth, $minDay ) = $minDateParts;
+			[ $minYear, $minMonth, $minDay ] = $minDateParts;
 		} else {
 			$minYear = $minDateParts[0];
 			$minMonth = $minDay = 0;
@@ -319,7 +370,7 @@ END;
 		if ( count( $maxDateParts ) == 3 ) {
 			// check if array can be used instead of list
 			// [ $maxYear, $maxMonth, $maxDay ] = $maxDateParts;
-			list( $maxYear, $maxMonth, $maxDay ) = $maxDateParts;
+			[ $maxYear, $maxMonth, $maxDay ] = $maxDateParts;
 		} else {
 			$maxYear = $maxDateParts[0];
 			$maxMonth = $maxDay = 0;

--- a/includes/Specials/BrowseData/GetApplicableFilters.php
+++ b/includes/Specials/BrowseData/GetApplicableFilters.php
@@ -119,9 +119,9 @@ class GetApplicableFilters {
 	 * the "results" (values) for this filter has been created.
 	 */
 	private function getFilterLine( $filterName, $isApplied, $isNormalFilter, $resultsLine, Filter $filter ): string {
-		global $wgScriptPath;
+		global $wgExtensionAssetsPath;
 		global $wgSdgDisableFilterCollapsible;
-		$sdSkinsPath = "$wgScriptPath/extensions/SemanticDrilldown/skins";
+		$sdSkinsPath = "$wgExtensionAssetsPath/SemanticDrilldown/skins";
 
 		if ( $filter->int() !== null ) {
 			$filterName = wfMessage( $filter->int() )->text();

--- a/includes/Specials/BrowseData/GetAppliedFilters.php
+++ b/includes/Specials/BrowseData/GetAppliedFilters.php
@@ -21,8 +21,8 @@ class GetAppliedFilters {
 	}
 
 	public function __invoke(): array {
-		global $wgScriptPath;
-		$sdSkinsPath = $wgScriptPath . '/extensions/SemanticDrilldown/skins';
+		global $wgExtensionAssetsPath;
+		$sdSkinsPath = $wgExtensionAssetsPath . '/SemanticDrilldown/skins';
 
 		$remainingHtml = '';
 		$subcategory_text = wfMessage( 'sd_browsedata_subcategory' )->text();

--- a/includes/Specials/BrowseData/QueryPage.php
+++ b/includes/Specials/BrowseData/QueryPage.php
@@ -124,7 +124,7 @@ class QueryPage extends \QueryPage {
 		if ( !$this->query ) {
 			return 'select null as sortkey where 0 = 1';
 		}
-		$dbr = smwfGetStore()->getConnection( 'mw.db' );
+		$dbr = smwfGetStore()->getConnection( DB_REPLICA );
 		$smwIDs = $dbr->tableName( Utils::getIDsTableName() );
 		$smwCategoryInstances = $dbr->tableName( Utils::getCategoryInstancesTableName() );
 		$cat_ns = NS_CATEGORY;
@@ -331,7 +331,7 @@ class QueryPage extends \QueryPage {
 	}
 
 	protected function getRecacheDB() {
-		return smwfGetStore()->getConnection( 'mw.db' );
+		return smwfGetStore()->getConnection( DB_REPLICA );
 	}
 
 

--- a/includes/Specials/BrowseData/QueryPage.php
+++ b/includes/Specials/BrowseData/QueryPage.php
@@ -124,7 +124,7 @@ class QueryPage extends \QueryPage {
 		if ( !$this->query ) {
 			return 'select null as sortkey where 0 = 1';
 		}
-		$dbr = \MediaWiki\MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
+		$dbr = smwfGetStore()->getConnection( 'mw.db' );
 		$smwIDs = $dbr->tableName( Utils::getIDsTableName() );
 		$smwCategoryInstances = $dbr->tableName( Utils::getCategoryInstancesTableName() );
 		$cat_ns = NS_CATEGORY;
@@ -329,5 +329,10 @@ class QueryPage extends \QueryPage {
 	protected function linkParameters() {
 		return $this->urlService->getLinkParameters( $this->getRequest(), $this->query );
 	}
+
+	protected function getRecacheDB() {
+		return smwfGetStore()->getConnection( 'mw.db' );
+	}
+
 
 }

--- a/includes/Specials/BrowseData/SpecialBrowseData.php
+++ b/includes/Specials/BrowseData/SpecialBrowseData.php
@@ -41,8 +41,8 @@ class SpecialBrowseData extends IncludableSpecialPage {
 	}
 
 	public function execute( $query ): void {
-		global $wgScriptPath, $sdgNumResultsPerPage;
-		$sdSkinsPath = "$wgScriptPath/extensions/SemanticDrilldown/skins";
+		global $wgExtensionAssetsPath, $sdgNumResultsPerPage;
+		$sdSkinsPath = "$wgExtensionAssetsPath/SemanticDrilldown/skins";
 
 		$out = $this->getOutput();
 		$request = $this->getRequest();

--- a/includes/Sql/SqlProvider.php
+++ b/includes/Sql/SqlProvider.php
@@ -48,9 +48,8 @@ class SqlProvider {
 	 * @return string
 	 */
 	public static function getSQLFromClauseForCategory( $subcategory, $child_subcategories ) {
-		$dbr = MediaWikiServices::getInstance()
-			->getDBLoadBalancer()
-			->getMaintenanceConnectionRef( DB_REPLICA );
+		// Fandom change - use connection to external SMW cluster
+		$dbr = smwfGetStore()->getConnection( DB_REPLICA );
 		$smwIDs = $dbr->tableName( Utils::getIDsTableName() );
 		$smwCategoryInstances = $dbr->tableName( Utils::getCategoryInstancesTableName() );
 		$ns_cat = NS_CATEGORY;
@@ -81,9 +80,8 @@ class SqlProvider {
 	 * @return string
 	 */
 	public static function getSQLFromClause( string $category, string $subcategory, array $subcategories, array $applied_filters ) {
-		$dbr = MediaWikiServices::getInstance()
-			->getDBLoadBalancer()
-			->getMaintenanceConnectionRef( DB_REPLICA );
+		// Fandom change - use connection to external SMW cluster
+		$dbr = smwfGetStore()->getConnection( DB_REPLICA );
 		$smwIDs = $dbr->tableName( Utils::getIDsTableName() );
 		$smwCategoryInstances = $dbr->tableName( Utils::getCategoryInstancesTableName() );
 		$cat_ns = NS_CATEGORY;

--- a/includes/TemporaryTableManager.php
+++ b/includes/TemporaryTableManager.php
@@ -2,19 +2,17 @@
 
 namespace SD;
 
-use DatabaseBase;
-
 /**
  * Provides helper method to execute SQL queries in auto-commit mode
  */
 
 class TemporaryTableManager {
-	/** @var \Wikimedia\Rdbms\IDatabase|DatabaseBase */
+	/** @var \Wikimedia\Rdbms\IDatabase */
 	private $databaseConnection;
 
 	/**
 	 * TemporaryTableManager constructor.
-	 * @param \Wikimedia\Rdbms\IDatabase|DatabaseBase $databaseConnection the DB connection to execute queries against
+	 * @param \Wikimedia\Rdbms\IDatabase $databaseConnection the DB connection to execute queries against
 	 */
 	public function __construct( $databaseConnection ) {
 		$this->databaseConnection = $databaseConnection;
@@ -28,6 +26,9 @@ class TemporaryTableManager {
 	 * @param string $method method name to log for query, defaults to this method
 	 */
 	public function queryWithAutoCommit( $sqlQuery, $method = __METHOD__ ) {
+		// PLATFORM-9138: temporary table queries with leading spaces are not recognized properly by mediawiki
+		$sqlQuery = trim( $sqlQuery );
+		/* UGC-4179
 		$wasAutoTrx = $this->databaseConnection->getFlag( DBO_TRX );
 		$this->databaseConnection->clearFlag( DBO_TRX );
 
@@ -35,9 +36,9 @@ class TemporaryTableManager {
 		if ( $wasAutoTrx && $this->databaseConnection->trxLevel() ) {
 			$this->databaseConnection->startAtomic( __METHOD__ );
 		}
-
+		*/
 		$this->databaseConnection->query( $sqlQuery, $method );
-
+		/* UGC-4179
 		if ( $wasAutoTrx && $this->databaseConnection->trxLevel() ) {
 			$this->databaseConnection->endAtomic( __METHOD__ );
 		}
@@ -45,5 +46,6 @@ class TemporaryTableManager {
 		if ( $wasAutoTrx ) {
 			$this->databaseConnection->setFlag( DBO_TRX );
 		}
+		*/
 	}
 }

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -17,8 +17,15 @@ use SMW\SQLStore\SQLStore;
 class Utils {
 
 	public static function setGlobalJSVariables( &$vars ) {
-		global $wgScriptPath;
-		$sdSkinsPath = "$wgScriptPath/extensions/SemanticDrilldown/skins";
+		/*
+		 * Fandom change - start
+		 * Use correct ext path to make it work in our dockerized setup
+		 */
+		global $wgExtensionAssetsPath;
+		$sdSkinsPath = "$wgExtensionAssetsPath/SemanticDrilldown/skins";
+		/*
+		 * Fandom change - end
+		 */
 
 		$vars['sdgDownArrowImage'] = "$sdSkinsPath/down-arrow.png";
 		$vars['sdgRightArrowImage'] = "$sdSkinsPath/right-arrow.png";


### PR DESCRIPTION
Changes include:
- Porting https://github.com/Wikia/mediawiki-extensions-SemanticDrilldown/commit/e3be797f58f8ff28b211b652c0c9b2193a38553a to work with the new upstream
- Spitting a cross-cluster JOIN into two separate queries - see https://github.com/Wikia/SemanticDrilldown/commit/081d480962a8b663527a7c089c829bfb693aadfb
- https://github.com/Wikia/mediawiki-extensions-SemanticDrilldown/pull/4 and https://github.com/Wikia/mediawiki-extensions-SemanticDrilldown/pull/3
- Use correct assets paths (we have a different setup from what the upstream expects)


Old upstream patches reapplied to the new fork:
- https://github.com/Wikia/mediawiki-extensions-SemanticDrilldown/commits/e3be797f58f8ff28b211b652c0c9b2193a38553a
