### PR TITLE
fix(PLATFORM-10826): fix PHP Warning: Undefined array key "o_id"

### DIFF
--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -335,7 +335,9 @@ END;
 			$possible_values[] = new PossibleFilterValue(
 				$value_string,
 				$row['count'],
-				htmlspecialchars_decode( $o_ids_to_displaytitle[$row['o_id']] ?? '' )
+				isset( $row['o_id'] ) && isset( $o_ids_to_displaytitle[$row['o_id']] )
+					? htmlspecialchars_decode( $o_ids_to_displaytitle[$row['o_id']] )
+					: ''
 			);
 		}
 


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-10826

This PR fixes the `PHP Warning: Undefined array key "o_id"` error. In MediaWiki 1.43 relaying on coalesce operator `??` when accessing non-existent array keys produces such a warning and it is logged by MediaWiki on level ERROR which obscures the real state of the platform.
