### PR TITLE
fix: get rid of erorr on Special:BrowseData

### DIFF
--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -374,11 +374,16 @@ class AppliedFilter {
 				$value_string = str_replace( '_', ' ', $row['value'] );
 			}
 
+			$displayTitle = null;
+			if ( array_key_exists( 'o_id', $row ) ) {
+				$displayTitle = htmlspecialchars_decode( $o_ids_to_displaytitle[$row['o_id']] ?? '' );
+			}
+
 			$possible_values[] = new PossibleFilterValue(
 				$value_string,
 				null,
 				// Fandom change - fetch displayTitle from the array instead
-				htmlspecialchars_decode( $o_ids_to_displaytitle[$row['o_id']] ?? '' )
+				$displayTitle
 			);
 		}
 		return new PossibleFilterValues( $possible_values );


### PR DESCRIPTION
This produces a lot of:

```
PHP Warning: Undefined array key "o_id" in /extensions/SemanticDrilldown/includes/AppliedFilter.php on line 381
```